### PR TITLE
chapter-04: add the missing `S` of `SYSCTL_INT`

### DIFF
--- a/content/chapters/part1/chapter-04.md
+++ b/content/chapters/part1/chapter-04.md
@@ -3081,7 +3081,7 @@ If you follow `_if_delgroup_locked()` from start to finish, you can watch all th
 
 A little further down, the calls to `free(...)` deal with dynamic storage. The pointers passed to `free()` were created earlier in the driver's life, often with `malloc()` during initialisation routines like `if_addgroup()`. Unlike stack variables, this memory stays around until the driver deliberately lets it go. Freeing it here tells the kernel, *"I'm done with this; you can reuse it for something else."*
 
-This function doesn't use static variables directly, but in the same file (`if.c`), you will find examples like debugging flags declared with `YSCTL_INT` that live for as long as the kernel module is loaded. These variables keep their values across function calls and are a reliable place to store configuration or diagnostics that need to persist.
+This function doesn't use static variables directly, but in the same file (`if.c`), you will find examples like debugging flags declared with `SYSCTL_INT` that live for as long as the kernel module is loaded. These variables keep their values across function calls and are a reliable place to store configuration or diagnostics that need to persist.
 
 Each choice here is intentional.
 

--- a/translations/es_ES/chapters/part1/chapter-04.md
+++ b/translations/es_ES/chapters/part1/chapter-04.md
@@ -3080,7 +3080,7 @@ Si sigues `_if_delgroup_locked()` de principio a fin, puedes observar cómo las 
 
 Un poco más adelante, las llamadas a `free(...)` tratan con el almacenamiento dinámico. Los punteros pasados a `free()` se crearon anteriormente en la vida del driver, normalmente con `malloc()` durante rutinas de inicialización como `if_addgroup()`. A diferencia de las variables de stack, esta memoria permanece hasta que el driver la libera deliberadamente. Liberarla aquí le indica al kernel: *«He terminado con esto; puedes reutilizarlo para otra cosa.»*
 
-Esta función no usa variables estáticas directamente, pero en el mismo archivo (`if.c`) encontrarás ejemplos como indicadores de depuración declarados con `YSCTL_INT` que viven mientras el módulo del kernel está cargado. Estas variables conservan sus valores entre llamadas a funciones y son un lugar fiable para almacenar configuración o diagnósticos que necesitan persistir.
+Esta función no usa variables estáticas directamente, pero en el mismo archivo (`if.c`) encontrarás ejemplos como indicadores de depuración declarados con `SYSCTL_INT` que viven mientras el módulo del kernel está cargado. Estas variables conservan sus valores entre llamadas a funciones y son un lugar fiable para almacenar configuración o diagnósticos que necesitan persistir.
 
 Cada decisión aquí es deliberada.
 

--- a/translations/pt_BR/chapters/part1/chapter-04.md
+++ b/translations/pt_BR/chapters/part1/chapter-04.md
@@ -3082,7 +3082,7 @@ Se você acompanhar `_if_delgroup_locked()` do início ao fim, pode observar as 
 
 Um pouco mais adiante, as chamadas a `free(...)` tratam do armazenamento dinâmico. Os ponteiros passados a `free()` foram criados anteriormente na vida do driver, frequentemente com `malloc()` durante rotinas de inicialização como `if_addgroup()`. Ao contrário das variáveis de stack, essa memória permanece até que o driver deliberadamente a libere. Liberá-la aqui informa ao kernel: *"Terminei com isso; você pode reutilizá-la para outra coisa."*
 
-Esta função não usa variáveis estáticas diretamente, mas no mesmo arquivo (`if.c`), você encontrará exemplos como flags de depuração declaradas com `YSCTL_INT` que vivem enquanto o módulo do kernel estiver carregado. Essas variáveis mantêm seus valores entre chamadas de função e são um local confiável para armazenar configurações ou diagnósticos que precisam persistir.
+Esta função não usa variáveis estáticas diretamente, mas no mesmo arquivo (`if.c`), você encontrará exemplos como flags de depuração declaradas com `SYSCTL_INT` que vivem enquanto o módulo do kernel estiver carregado. Essas variáveis mantêm seus valores entre chamadas de função e são um local confiável para armazenar configurações ou diagnósticos que precisam persistir.
 
 Cada escolha aqui é intencional.
 


### PR DESCRIPTION
Just adding a missing letter. Oddly the LLM already fixed it in zh_CN.