### PR TITLE
scripts/build-book.sh: Fix broken URL for Eisvogel

### DIFF
--- a/scripts/build-book.sh
+++ b/scripts/build-book.sh
@@ -396,7 +396,7 @@ test_dependencies() {
         echo "   ✓ Template size: $template_size"
     else
         echo "   ✗ Eisvogel template not found at: $EISVOGEL_TEMPLATE"
-        echo "   💡 Install with: wget -O $EISVOGEL_TEMPLATE https://raw.githubusercontent.com/Wandmalfarbe/pandoc-latex-template/master/eisvogel.tex"
+        echo "   💡 Follow installation instructions: https://github.com/Wandmalfarbe/pandoc-latex-template#installation"
         all_good=false
     fi
 


### PR DESCRIPTION
The URL on gist.github.com doesn't work, and the current instructions seem to indicate that the template should be installed in two files rather than just one.